### PR TITLE
pass a texture array rather than Observable obj as texture uniform

### DIFF
--- a/src/components/Viz.vue
+++ b/src/components/Viz.vue
@@ -474,11 +474,16 @@ export default {
       console.log('painting atlas')
       if (!this.showAtlases) return
       if (this.filesObject) {
-        this.filesObject.material.uniforms.texture.value = this.atlases[
-          this.currentBucket.key
-        ]
+        const arr = [],
+            observable = this.atlases[this.currentBucket.key];
+        for (let i=0; i<Number.POSITIVE_INFINITY; i++) {
+          if (observable[i]) arr.push(observable[i])
+          else break;
+        }
+        this.filesObject.material.uniforms.texture.value = arr
         this.filesObject.material.uniforms.loadedAtlases.value = 1.0
-        this.filesObject.material.uniformsNeedUpdate = true
+        this.filesObject.material.uniforms.texture.needsUpdate = true
+        this.filesObject.material.uniforms.loadedAtlases.needsUpdate = true
       }
     },
     initFiles(obj) {


### PR DESCRIPTION
This PR fixes the use of multi-texture uniforms.

It took a second to track down, but evidently the object that was being passed as the texture uniform was not an array of textures but rather a Vue Observer object!

To transform the array to a flat array of textures, I just iterated over the observer and plucked out its values. Now multi-texture uniforms behave as expected.

I also updated the uniform needs update setters, as I believe the blanket [`.uniformsNeedUpdate`](https://threejs.org/docs/#api/en/materials/ShaderMaterial.uniformsNeedUpdate) is only available on `THREE.ShaderMaterial` rather than the `THREE.RawShaderMaterial` that's  used here...